### PR TITLE
Adding support for parameterized join conditions

### DIFF
--- a/src/Query/AbstractJoin.php
+++ b/src/Query/AbstractJoin.php
@@ -3,6 +3,9 @@
 namespace Happyr\DoctrineSpecification\Query;
 
 use Doctrine\ORM\QueryBuilder;
+use Happyr\DoctrineSpecification\Filter\Filter;
+use Happyr\DoctrineSpecification\Spec;
+use Happyr\DoctrineSpecification\Specification\Specification;
 
 /**
  * @author Tobias Nyholm
@@ -52,7 +55,7 @@ abstract class AbstractJoin implements QueryModifier
 
     /**
      * @param QueryBuilder $qb
-     * @param string       $dqlAlias
+     * @param string $dqlAlias
      */
     public function modify(QueryBuilder $qb, $dqlAlias)
     {
@@ -60,7 +63,15 @@ abstract class AbstractJoin implements QueryModifier
             $dqlAlias = $this->dqlAlias;
         }
 
+        if (!($this->condition instanceof Specification) && $this->condition instanceof Filter) {
+            $this->condition = Spec::andX($this->condition);
+        }
+
+        $condition = ($this->condition instanceof Specification)
+            ? (string)$this->condition->getFilter($qb, $dqlAlias)
+            : $this->condition;
+
         $join = $this->getJoinType();
-        $qb->$join(sprintf('%s.%s', $dqlAlias, $this->field), $this->newAlias, 'WITH', $this->condition);
+        $qb->$join(sprintf('%s.%s', $dqlAlias, $this->field), $this->newAlias, 'WITH', $condition);
     }
 }


### PR DESCRIPTION
Currently a common pattern  is to do inner joins with a condition in order to limit the results, eg 

```
Spec::innerJoin('job_status', 'js', 'j', 'js.id IN('.implode(",", $this->getFilterValue('job_status')).')')
```

or 
```
Spec::innerJoin('client', 'c', 'j', 'CONCAT(c.first_name, c.last_name) LIKE \'%' . $this->getFilterValue('client') . '%\'')
```

This approach vulnerable to SQL injection attacks, we need a way to create parameterized conditions on our joins.


This pull request adds support for parameterized join conditions like below
```php
Spec::innerJoin('project_manager', 'pm', 'j', 
    Spec::in('pm.id', $this->getFilterValue('project_manager')));
```